### PR TITLE
fix: typo in the interface name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,7 +73,7 @@ export interface ContentTypeCollection {
 export type LivePreview = {
     host?: string
     enable: boolean
-} & (LivePreivewConfigWithManagementToken | LivePreivewConfigWithPreviewToken)
+} & (LivePreivewConfigWithManagementToken | LivePreviewConfigWithPreviewToken)
 
 export interface LivePreivewConfigWithManagementToken {
     /**
@@ -83,7 +83,7 @@ export interface LivePreivewConfigWithManagementToken {
     management_token: string;
 }
 
-export interface LivePreivewConfigWithPreviewToken {
+export interface LivePreviewConfigWithPreviewToken {
     preview_token: string;
 }
 


### PR DESCRIPTION
The interface `LivePreivewConfigWithPreviewToken` should be `LivePreviewConfigWithPreviewToken`

fixes: https://contentstack.atlassian.net/browse/EB-634